### PR TITLE
Change build workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,31 +6,154 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
-
-on:
-  release:
-    types: [published]
+name: Publish Python distribution to PyPI and TestPyPI
 
 permissions:
   contents: read
 
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v**"
+
 jobs:
-  release:
-    environment: production
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
+    outputs:
+      git_version: ${{ steps.versions.outputs.git_version }}
+      hatch_version: ${{ steps.versions.outputs.hatch_version }}
+      versions_match: ${{ steps.versions.outputs.versions_match }}
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5.2.0
       with:
-        python-version: '3.x'
-    - name: Install dependencies
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install hatch
+      run: >-
+        python3 -m
+        pip install
+        hatch
+        --user
+    - name: Match git tag to package version
+      id: versions
       run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597
+        echo "git_version=$(git describe --tags | sed -Ee 's/v(.*)/\1/')" >> $GITHUB_OUTPUT
+        echo "hatch_version=$(hatch version)" >> $GITHUB_OUTPUT
+        if [ $(git describe --tags | sed -Ee 's/v(.*)/\1/') = $(hatch version) ]
+        then
+          echo "versions_match=true" >> $GITHUB_OUTPUT
+        else
+          echo "versions_match=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Log versions
+      env:
+        HATCH_VERSION: ${{ steps.versions.outputs.hatch_version }}
+        GIT_VERSION: ${{ steps.versions.outputs.git_version }}
+        VERSIONS_MATCH: ${{ steps.versions.outputs.versions_match }}
+      run: |
+        echo "$HATCH_VERSION" "$GIT_VERSION" "$VERSIONS_MATCH"
+    - name: Build a binary wheel and a source tarball
+      run: hatch build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.versions_match == 'true'  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/abnormal-hieratic-indexer
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/abnormal-hieratic-indexer
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "beautifulsoup4~=4.12.3",
   "requests~=2.32.3",
 ]
-version = "1.0.1"
+version = "1.0.2"
 
 [project.urls]
 Documentation = "https://github.com/LeidenUniversityLibrary/abnormal-hieratic-indexer#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.25.0"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Require a newer hatchling, so that the built package's metadata version is 2.4.
The GitHub workflow is copied and adapted from [mkdocs-ubleiden-theme](https://github.com/LeidenUniversityLibrary/mkdocs-ubleiden-theme).

To put this to the test, bump the package version to 1.0.2