### PR TITLE
Index annotation records using `_doc` endpoint

### DIFF
--- a/abnormal_hieratic_indexer/index_annotations.py
+++ b/abnormal_hieratic_indexer/index_annotations.py
@@ -140,7 +140,7 @@ class Indexer:
     def index_annotation_record(self, record):
         self.LOGGER.info("Updating %s", record["id"])
 
-        res = self.SESSION.put(self.ES_ENDPOINT + self.ES_INDEX + record["id"], json=record)
+        res = self.SESSION.put(self.ES_ENDPOINT + self.ES_INDEX + "_doc/" + record["id"], json=record)
         self.LOGGER.info("Update returned status: %s", res.status_code)
         self.LOGGER.debug(res.json())
         res.raise_for_status()
@@ -160,7 +160,7 @@ def main():
     parser.add_argument("target", help="Base URL for ElasticSearch (default: %(default)s)", default="http://localhost:9200")
     parser.add_argument("--canvas-uri-prefix", help="Index only annotations targeting canvases whose URIs start with this prefix (default: %(default)s)",
     default="https://lab.library.universiteitleiden.nl/manifests/external/louvre/")
-    parser.add_argument("--index", help="URI path to the ElasticSearch index (default: %(default)s)", default="/annotations/anno/")
+    parser.add_argument("--index", help="URI path to the ElasticSearch index (default: %(default)s)", default="/annotations/")
     args = parser.parse_args()
     indexer = Indexer(args)
     indexer.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "beautifulsoup4~=4.12.3",
   "requests~=2.32.3",
 ]
-version = "1.0.2"
+version = "1.1.0"
 
 [project.urls]
 Documentation = "https://github.com/LeidenUniversityLibrary/abnormal-hieratic-indexer#readme"


### PR DESCRIPTION
In older versions of Elasticsearch we used a mapping type next to the index name, but v8.x doesn't support mapping types anymore. To index a document using `PUT`, we need to use the `<index>/_doc/<id>` API.