### PR TITLE
Fix README rendering of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ optional arguments:
   --canvas-uri-prefix CANVAS_URI_PREFIX
                         Index only annotations targeting canvases whose URIs start with this prefix (default:
                         https://lab.library.universiteitleiden.nl/manifests/external/louvre/)
-  --index INDEX         URI path to the ElasticSearch index (default: /annotations/anno/)
+  --index INDEX         URI path to the ElasticSearch index (default: /annotations/)
 ```
 
 To enable periodic indexing, you can set up a cronjob or Systemd timer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "beautifulsoup4~=4.12.3",
   "requests~=2.32.3",
 ]
-version = "1.0.2"
+version = "1.1.1"
 
 [project.urls]
 Documentation = "https://github.com/LeidenUniversityLibrary/abnormal-hieratic-indexer#readme"


### PR DESCRIPTION
Make the usage section in the README the same as the actual output of `-h`. Bump to 1.1.1