### PR TITLE
URL-encode ES document IDs

### DIFF
--- a/abnormal_hieratic_indexer/index_annotations.py
+++ b/abnormal_hieratic_indexer/index_annotations.py
@@ -140,7 +140,7 @@ class Indexer:
     def index_annotation_record(self, record):
         self.LOGGER.info("Updating %s", record["id"])
 
-        res = self.SESSION.put(self.ES_ENDPOINT + self.ES_INDEX + "_doc/" + record["id"], json=record)
+        res = self.SESSION.put(self.ES_ENDPOINT + self.ES_INDEX + "_doc/" + requests.utils.quote(record["id"], safe=''), json=record)
         self.LOGGER.info("Update returned status: %s", res.status_code)
         self.LOGGER.debug(res.json())
         res.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "requests~=2.32.3",
 ]
 
-version = "1.1.1"
+version = "1.1.2"
 
 [project.urls]
 Documentation = "https://github.com/LeidenUniversityLibrary/abnormal-hieratic-indexer#readme"


### PR DESCRIPTION
In the dev env, full URIs are used as IDs. ES doesn't accept them as they are.

Bump patch version